### PR TITLE
with_something implementation

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -3,6 +3,7 @@ Title: Run Code 'With' Temporarily Modified Global State
 Version: 0.0.0.9001
 Authors@R: c(
     person("Jim", "Hester", , "james.f.hester@gmail.com", role = c("aut", "cre")),
+    person("Kirill", "Müller", , "krlmlr+r@mailbox.org", role = "aut"),
     person("Hadley", "Wickham", , "hadley@rstudio.com", role = "aut"),
     person("Winston", "Chang", role = "aut"),
     person("RStudio", role = "cph"),

--- a/R/with.R
+++ b/R/with.R
@@ -18,17 +18,12 @@
 #' )
 NULL
 
-with_something <- function(set, reset = set) {
+with_something <- function(set, reset = set, envir = parent.frame()) {
 
   fmls <- formals(set)
 
   # called pass all extra formals on
   called_fmls <- setNames(lapply(names(fmls), as.symbol), names(fmls))
-
-  # when used in a call ... need to be the value, not the name
-  if (!is.null(called_fmls[["..."]])) {
-    names(called_fmls)[names(called_fmls) == "..."] <- ""
-  }
 
   # rename first formal to new
   called_fmls[[1]] <- as.symbol("new")
@@ -44,6 +39,8 @@ with_something <- function(set, reset = set) {
 
   # substitute does not work on arguments, so we need to fix them manually
   formals(fun) <- c(alist(new =, code =), fmls[-1])
+
+  environment(fun) <- envir
 
   fun
 }

--- a/man/with_something.Rd
+++ b/man/with_something.Rd
@@ -26,7 +26,7 @@ with_libpaths(new, code, action = "replace")
 
 with_options(new, code)
 
-with_par(new, code)
+with_par(new, code, no.readonly = FALSE)
 
 with_path(new, code, action = "prefix")
 
@@ -40,6 +40,8 @@ with_makevars(new, code, path = file.path("~", ".R", "Makevars"))
 \item{action}{(for \code{with_envvar} and \code{with_path} only): should new values
 \code{"replace"}, \code{"suffix"}, \code{"prefix"} existing values?
 (For \code{with_envvar}, this refers to environmental variables with the same name.)}
+
+\item{no.readonly}{see \code{\link{par}} documentation.}
 
 \item{path}{location of existing makevars to modify.}
 }


### PR DESCRIPTION
This is an alternate implementation for `with_something()`.

It is similar to your fancy implementation except it

1. Any additional function arguments specified in `set` are added to the `with_` interface.  You don't need to specify them manually.
2. It correctly passes `...` onto set if it is in the original definition (and not the first argument)
3. Function names for both set and reset _are_ substituted.

Example outputs
```r
with_envvar
#> function (new, code, action = "replace")
#> {
#>     old <- set_envvar(envs = new, action = action)
#>     on.exit(set_envvar(old))
#>     force(code)
#> }

with_libpaths
#> function (new, code, action = "replace")
#> {
#>     old <- set_libpaths(paths = new, action = action)
#>     on.exit(.libPaths(old))
#>     force(code)
#> }

with_par
#> function (new, code, no.readonly = FALSE)
#> {
#>     old <- par(new, no.readonly = no.readonly)
#>     on.exit(par(old))
#>     force(code)
#> }
```

@krlmlr let me know what you think.